### PR TITLE
backwards compatibility effort

### DIFF
--- a/pyUSID/io/__init__.py
+++ b/pyUSID/io/__init__.py
@@ -28,6 +28,7 @@ from .array_translator import ArrayTranslator
 from .image import ImageTranslator
 from .dimension import DimType, Dimension
 
+# For legacy reasons
 write_utils = anc_build_utils
 
 __all__ = ['USIDataset', 'hdf_utils', 'write_utils', 'Dimension', 'DimType',

--- a/pyUSID/io/anc_build_utils.py
+++ b/pyUSID/io/anc_build_utils.py
@@ -13,11 +13,13 @@ import sys
 import numpy as np
 from sidpy.base.num_utils import contains_integers
 from sidpy.base.string_utils import validate_list_of_strings
-from .dimension import Dimension, DimType
+# For legacy reasons
+from .dimension import Dimension, DimType, validate_dimensions
 
 __all__ = ['get_aux_dset_slicing', 'make_indices_matrix', 'INDICES_DTYPE',
            'VALUES_DTYPE', 'build_ind_val_matrices', 'calc_chunks',
-           'create_spec_inds_from_vals', 'Dimension', 'DimType']
+           'create_spec_inds_from_vals',
+           'Dimension', 'DimType', 'validate_dimensions']
 
 if sys.version_info.major == 3:
     unicode = str


### PR DESCRIPTION
1. Importing ``validate_dimension()`` back into ``anc_build_utils``
2. ``write_utils`` was already set equal to ``anc_build_utils`` so backwards compatibility was already considered (if not completely). 
3. ``Dimension`` and ``DimType`` were already imported into ``anc_build_utils``

Thanks for pointing these out @rajgiriUW 