### PR TITLE
Fix expired deprecation for NumPy 1.24

### DIFF
--- a/pyUSID/io/usi_data.py
+++ b/pyUSID/io/usi_data.py
@@ -358,7 +358,7 @@ class USIDataset(h5py.Dataset):
                                'dimensions are {}.'.format(key,
                                                            self.n_dim_labels))
             if not isinstance(val, (slice, list, np.ndarray, tuple, int,
-                                    np.int, np.int64, np.int32, np.int16)):
+                                    np.int64, np.int32, np.int16)):
                 raise TypeError('The values for a slice must be a slice, list,'
                                 ' numpy array, a tuple, or an int. Provided '
                                 'value: {} for dimension: {} was of type: {}'

--- a/tests/io/test_dimension.py
+++ b/tests/io/test_dimension.py
@@ -42,7 +42,7 @@ class TestDimension(unittest.TestCase):
         name = 'Bias'
         quantity = 'generic'
         units = 'V'
-        values = np.arange(5, dtype=np.float)
+        values = np.arange(5, dtype=float)
 
         descriptor = dimension.Dimension(name, units, len(values))
         print(type(descriptor))


### PR DESCRIPTION
NumPy 1.24 removed a couple of deprecated aliases for plain python types such as `int` and `float`.